### PR TITLE
Fixed issue related to "no documents in result" on first run

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -138,21 +138,16 @@ func (m *Migrate) Version() (uint64, string, error) {
 
 	// find record with greatest id (assuming it`s latest also)
 	result := m.db.Collection(m.migrationsCollection).FindOne(context.TODO(), filter, options)
-	if err := result.Err(); err != nil {
-		if err == mongo.ErrNoDocuments {
-			return 0, "", nil
-		}
-
+	err := result.Err()
+	switch {
+	case err == mongo.ErrNoDocuments:
+		return 0, "", nil
+	case err != nil:
 		return 0, "", err
 	}
 
 	var rec versionRecord
-	err := result.Decode(&rec)
-	if err != nil {
-		if err == mongo.ErrNoDocuments {
-			return 0, "", nil
-		}
-
+	if err := result.Decode(&rec); err != nil {
 		return 0, "", err
 	}
 

--- a/migrate.go
+++ b/migrate.go
@@ -139,6 +139,10 @@ func (m *Migrate) Version() (uint64, string, error) {
 	// find record with greatest id (assuming it`s latest also)
 	result := m.db.Collection(m.migrationsCollection).FindOne(context.TODO(), filter, options)
 	if err := result.Err(); err != nil {
+		if err == mongo.ErrNoDocuments {
+			return 0, "", nil
+		}
+
 		return 0, "", err
 	}
 

--- a/migration_integration_test.go
+++ b/migration_integration_test.go
@@ -70,6 +70,9 @@ func TestMain(m *testing.M) {
 	addr, err := url.Parse(os.Getenv("MONGO_URL"))
 	opt := options.Client().ApplyURI(addr.String())
 	client, err := mongo.NewClient(opt)
+	if err != nil {
+		panic(err)
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 	err = client.Connect(ctx)


### PR DESCRIPTION
# Context

I was getting the following error when no documents were present in the `migrations` collection (first run):

```
mongo: no documents in result
```

# Fix

Adding an additional check (exact same condition as the one a few lines below) fixed that issue.