### PR TITLE
I fixed the warnings in GitHub Actions.

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -10,10 +10,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: "1.20"
 
@@ -23,7 +23,7 @@ jobs:
       - name: Test
         run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
 
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.txt


### PR DESCRIPTION
These are the latest.
- https://github.com/actions/checkout/tree/v4/
- https://github.com/actions/setup-go/tree/v4/
- https://github.com/codecov/codecov-action/tree/v3/