### PR TITLE
fix: should not pass nil to context

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -78,7 +78,6 @@ func (m *Migrate) createCollectionIfNotExist(name string) error {
 	}
 
 	command := bson.D{bson.E{Key: "create", Value: name}}
-	
 	if err = m.db.RunCommand(context.TODO(), command).Err(); err != nil {
 		return err
 	}

--- a/migrate.go
+++ b/migrate.go
@@ -78,8 +78,8 @@ func (m *Migrate) createCollectionIfNotExist(name string) error {
 	}
 
 	command := bson.D{bson.E{Key: "create", Value: name}}
-	err = m.db.RunCommand(nil, command).Err()
-	if err != nil {
+	
+	if err = m.db.RunCommand(context.TODO(), command).Err(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
I fixed the warning. According to the page below, we should use context.TODO() instead of nil.

https://pkg.go.dev/context#TODO
> TODO returns a non-nil, empty [Context](https://pkg.go.dev/context#Context). Code should use context.TODO when it's unclear which Context to use or it is not yet available (because the surrounding function has not yet been extended to accept a Context parameter).